### PR TITLE
add query filtering to BatchToSEList()

### DIFF
--- a/rsbe/batchtose.go
+++ b/rsbe/batchtose.go
@@ -1,20 +1,22 @@
 package rsbe
 
 import (
+	"github.com/google/go-querystring/query"
+
 	"encoding/json"
-		"fmt"
+	"fmt"
 )
 
 type BatchToSEListEntry struct {
-	ID        string `json:"id,omitempty"`
-	BatchID   string `json:"batch_id,omitempty"`
-	SEID      string `json:"se_id,omitempty"`
-	Phase     string `json:"phase,omitempty"`
-	Step      string `json:"step,omitempty"`
-	Status    string `json:"status,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
-	URL       string `json:"url,omitempty"`
+	ID        string `json:"id,omitempty" url:"id,omitempty"`
+	BatchID   string `json:"batch_id,omitempty" url:"batch_id,omitempty"`
+	SEID      string `json:"se_id,omitempty" url:"se_id,omitempty"`
+	Phase     string `json:"phase,omitempty" url:"phase,omitempty"`
+	Step      string `json:"step,omitempty" url:"step,omitempty"`
+	Status    string `json:"status,omitempty" url:"status,omitempty"`
+	CreatedAt string `json:"created_at,omitempty" url:"-"`
+	UpdatedAt string `json:"updated_at,omitempty" url:"-"`
+	URL       string `json:"url,omitempty" url:"-"`
 }
 
 type BatchToSEEntry struct {
@@ -33,9 +35,37 @@ type BatchToSEEntry struct {
 	LockVersion   int    `json:"lock_version,omitempty"`
 }
 
-func BatchToSEList() (list []BatchToSEListEntry, err error) {
+// Get a list of BatchToSEListEntry objects
+// Function accepts 0 or 1 BatchToSEListEntry parameters.
 
-	body, err := GetBody("/api/v0/batch_to_ses")
+// If a BatchToSEListEntry parameter is passed, the BatchID, SEID,
+// Phase, Step, and Status fields are added to the RSBE query as query
+// params.
+func BatchToSEList(b ...BatchToSEListEntry) (list []BatchToSEListEntry, err error) {
+
+	path := "/api/v0/batch_to_ses"
+
+	// check if there are any query parameters
+	switch len(b) {
+	case 0:
+		// noop
+	case 1:
+		// extract url.Values 
+		v, err := query.Values(b[0])
+		if err != nil {
+			return nil, err
+		}
+
+		// if encoded values are not empty, append to path
+		if v.Encode() != "" {
+			path += "?" + v.Encode()
+		}
+	default:
+		return list, fmt.Errorf("error: can only accept 0 or 1 BatchToSEListEntry arguments")
+	}
+
+	
+	body, err := GetBody(path)
 	if err != nil {
 		return nil, err
 	}

--- a/rsbe/batchtose_test.go
+++ b/rsbe/batchtose_test.go
@@ -9,6 +9,16 @@ var batchToSEListEntry = BatchToSEListEntry{}
 
 var batchToSEShow = BatchToSEEntry{}
 
+var seToCreateForBatchToSETest = SEEntry{
+	ID:           "cee91db3-ee73-4953-a05e-98f043d44f97",
+	CollectionID: "b9612d5d-619a-4ceb-b620-d816e4b4340b",
+	DigiID:       "wakawaka",
+	DOType:       "audio",
+	Phase:        "digitization",
+	Step:         "digitization",
+	Status:       "canceled",
+}
+
 var batchToSEToCreate = BatchToSEEntry{
 	BatchID: "32626389-c942-4e71-9b5a-5d7c7ca4d389",
 	SEID:    "8c258cb2-d700-43be-8773-a61a7b9cd668",
@@ -16,6 +26,15 @@ var batchToSEToCreate = BatchToSEEntry{
 	Step:    "trimming",
 	Status:  "active",
 	Notes:   "amazing notes, as always",
+}
+
+var batchToSEToCreate2 = BatchToSEEntry{
+	BatchID: "32626389-c942-4e71-9b5a-5d7c7ca4d389",
+	SEID:    "cee91db3-ee73-4953-a05e-98f043d44f97",
+	Phase:   "baking",
+	Step:    "measuring-flour",
+	Status:  "covered-in-dust",
+	Notes:   "I wish I had a useful recipe",
 }
 
 func TestBatchToSECreateFunc(t *testing.T) {
@@ -87,6 +106,133 @@ func TestBatchToSEList(t *testing.T) {
 
 		if want.UpdatedAt != got.UpdatedAt {
 			t.Errorf("UpdatedAt mismatch: want: \"%v\", got: \"%v\"", want.UpdatedAt, got.UpdatedAt)
+		}
+	})
+
+	t.Run("check that proper attribute values are returned when an empty BatchToSEListEntry is passed", func(t *testing.T) {
+		list, err := BatchToSEList(BatchToSEListEntry{})
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
+
+		if 1 != len(list) {
+			t.Errorf("Mismatch: want: \"%v\", got: \"%v\"", 1, len(list))
+		}
+
+		want := batchToSEToCreate
+		got := list[0]
+
+		if want.ID != got.ID {
+			t.Errorf("ID mismatch: want: \"%v\", got: \"%v\"", want.ID, got.ID)
+		}
+
+		if want.BatchID != got.BatchID {
+			t.Errorf("BatchID mismatch: want: \"%v\", got: \"%v\"", want.BatchID, got.BatchID)
+		}
+
+		if want.SEID != got.SEID {
+			t.Errorf("SEID mismatch: want: \"%v\", got: \"%v\"", want.SEID, got.SEID)
+		}
+
+		if want.Phase != got.Phase {
+			t.Errorf("Phase mismatch: want: \"%v\", got: \"%v\"", want.Phase, got.Phase)
+		}
+
+		if want.Step != got.Step {
+			t.Errorf("Step mismatch: want: \"%v\", got: \"%v\"", want.Step, got.Step)
+		}
+
+		if want.Status != got.Status {
+			t.Errorf("Status mismatch: want: \"%v\", got: \"%v\"", want.Status, got.Status)
+		}
+
+		if want.CreatedAt != got.CreatedAt {
+			t.Errorf("CreatedAt mismatch: want: \"%v\", got: \"%v\"", want.CreatedAt, got.CreatedAt)
+		}
+
+		if want.UpdatedAt != got.UpdatedAt {
+			t.Errorf("UpdatedAt mismatch: want: \"%v\", got: \"%v\"", want.UpdatedAt, got.UpdatedAt)
+		}
+	})
+
+	t.Run("check that proper list entries when a populated BatchToSEListEntry is passed", func(t *testing.T) {
+		// setup
+		err := seToCreateForBatchToSETest.Create()
+		if err != nil {
+			t.Errorf("Error setting up test: %s", err)
+		}
+		defer seToCreateForBatchToSETest.Delete()
+
+		err = batchToSEToCreate2.Create()
+		if err != nil {
+			t.Errorf("Error setting up test: %s", err)
+		}
+		defer batchToSEToCreate2.Delete()
+
+		// filter by BatchID
+		list, err := BatchToSEList(BatchToSEListEntry{BatchID: "32626389-c942-4e71-9b5a-5d7c7ca4d389"})
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
+
+		if 2 != len(list) {
+			t.Errorf("Mismatch: want: \"%v\", got: \"%v\"", 2, len(list))
+		}
+
+		// filter by SEID
+		list, err = BatchToSEList(BatchToSEListEntry{SEID: "8c258cb2-d700-43be-8773-a61a7b9cd668"})
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
+
+		if 1 != len(list) {
+			t.Errorf("Mismatch: want: \"%v\", got: \"%v\"", 1, len(list))
+		}
+
+		if "8c258cb2-d700-43be-8773-a61a7b9cd668" != list[0].SEID {
+			t.Errorf("ID mismatch: want: \"8c258cb2-d700-43be-8773-a61a7b9cd668\", got: \"%v\"", list[0].SEID)
+		}
+
+		// filter by Phase
+		list, err = BatchToSEList(BatchToSEListEntry{Phase: "baking"})
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
+
+		if 1 != len(list) {
+			t.Errorf("Mismatch: want: \"%v\", got: \"%v\"", 1, len(list))
+		}
+
+		if "cee91db3-ee73-4953-a05e-98f043d44f97" != list[0].SEID {
+			t.Errorf("Status filter error. Got unexpected SEID: %v", list[0].SEID)
+		}
+
+		// filter by Step
+		list, err = BatchToSEList(BatchToSEListEntry{Step: "trimming"})
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
+
+		if 1 != len(list) {
+			t.Errorf("Mismatch: want: \"%v\", got: \"%v\"", 1, len(list))
+		}
+
+		if "8c258cb2-d700-43be-8773-a61a7b9cd668" != list[0].SEID {
+			t.Errorf("ID mismatch: want: \"8c258cb2-d700-43be-8773-a61a7b9cd668\", got: \"%v\"", list[0].SEID)
+		}
+
+		// filter by Status
+		list, err = BatchToSEList(BatchToSEListEntry{Status: "covered-in-dust"})
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
+
+		if 1 != len(list) {
+			t.Errorf("Mismatch: want: \"%v\", got: \"%v\"", 1, len(list))
+		}
+
+		if "cee91db3-ee73-4953-a05e-98f043d44f97" != list[0].SEID {
+			t.Errorf("Status filter error. Got unexpected SEID: %v", list[0].SEID)
 		}
 	})
 }


### PR DESCRIPTION
The RSBE API has been enhanced to filter batch_to_se index responses
based on query parameters, e.g., `batch_id`, `se_id`, `phase`, `step`, `status`.

This commit modifies the `rsbe.BatchToSEList()` function to take
advantage of the new RSBE API filtering functionality while
maintaining `rsbe.BatchToSEList()` function signature compatibility.

The backwards compatibility was achieved by adding a variadic
`BatchSEListEntry` parameter to `rsbe.BatchSEList()`.