### PR TITLE
Chore/auth type to string

### DIFF
--- a/.env.test.yaml.example
+++ b/.env.test.yaml.example
@@ -2,14 +2,26 @@
 # Copy this file to .env.test.yaml and update with your test credentials
 # Then set: export APP_ENV_FILE_PATH=/path/to/.env.test.yaml
 
-environment: test
+# NOTE: THIS FILE IS FOR TESTING PURPOSES ONLY. 
+#       When using this library, it doesn't matter where you get your
+#       configuration values from. The important this is that you call 
+#       `rsbe.ConfigureClient(&config)` with a valid config struct before 
+#       making any API calls.
 
+environment: test
+default_config: cookie # default config to use for tests that hit the server
+                       # can be any config key listed under "configs"
+		                   # in this example the options are "basic" and "cookie"
 configs:
+  # Example configuration for basic authentication. 
+  # Update with your test base URL and credentials.
   basic:
     BaseURL:  "http://localhost:3000/"
     User:     "your_username"
     Password: "your_password"
   
+  # Example configuration for cookie-based authentication. 
+  # Update with your test base URL, credentials, and login path.
   cookie:
     BaseURL:   "http://localhost:3000/"
     User:      "your_email@example.com"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,25 @@
-## `go-rsbe-client`
+# `go-rsbe-client`
 
-This is an [`rsbe`](https://github.com/nyudlts/rsbe) API client package
-written in Golang.
+This repo contains a client package for the R* Back End (`RSBE`) API written in Go.  
+The library supports two forms of authentication:  
+
+* `HTTP Basic Auth`  (used with the [Rails-based `RSBE` implementation](https://github.com/nyudlts/rsbe))
+* cookie based authentication (used with the [Go-based `RSBE` implementation](https://github.com/nyudlts/go-rsbe))
+
+Before placing requests to either implementation, you must call the  
+`rsbe.ConfigureClient(&cfg)` function with a properly initialized `Config` variable.
+
+```go
+type Config struct {
+  BaseURL   string
+  User      string
+  Password  string
+  AuthType  string
+  LoginPath string
+}
+```
+
+Please reference the [`.env.test.yaml.example`](./.env.test.yaml.example) file for sample values.
 
 ## Testing
 
@@ -41,5 +59,5 @@ export APP_ENV_FILE_PATH=/path/to/.env.test.yaml
 go test ./...
 ```
 
-The test suite will validate that the `environment` field is set to `test` to prevent accidental modification of non-test databases.
-
+The test suite will validate that the `environment` field is set to `test`  
+to prevent accidental modification of non-test databases.

--- a/rsbe/client.go
+++ b/rsbe/client.go
@@ -9,11 +9,9 @@ import (
 	"net/http/cookiejar"
 )
 
-type AuthType string
-
 const (
-	AuthTypeBasic  AuthType = "basic"
-	AuthTypeCookie AuthType = "cookie"
+	AuthTypeBasic  string = "basic"
+	AuthTypeCookie string = "cookie"
 )
 
 type ErrMsg struct {
@@ -24,7 +22,7 @@ type Config struct {
 	BaseURL   string
 	User      string
 	Password  string
-	AuthType  AuthType
+	AuthType  string
 	LoginPath string
 }
 

--- a/rsbe/config_loader.go
+++ b/rsbe/config_loader.go
@@ -7,10 +7,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const UseDefaultConfig string = "use_default_config"
+
 // TestConfig represents the structure of the test configuration file
 type TestConfig struct {
-	Environment string                 `yaml:"environment"`
-	Configs     map[string]ConfigEntry `yaml:"configs"`
+	Environment   string                 `yaml:"environment"`
+	DefaultConfig string                 `yaml:"default_config"`
+	Configs       map[string]ConfigEntry `yaml:"configs"`
 }
 
 // ConfigEntry represents a configuration entry for a specific auth type
@@ -46,9 +49,21 @@ func LoadConfig() error {
 }
 
 // GetConfig returns a Config struct for the specified configuration key
+// passing the special key UseDefaultConfig to GetConfig selects the
+// default configuration specified in the config file under the "default_config" key.
+// This allows tests to specify which configuration (and therefore auth method)
+// to use without changing the test code.
 func GetConfig(key string) (*Config, error) {
+
 	if Cfg == nil {
 		return nil, fmt.Errorf("configuration not loaded. Call LoadConfig() first")
+	}
+
+	if key == UseDefaultConfig {
+		if Cfg.DefaultConfig == "" {
+			return nil, fmt.Errorf("default_config not specified in config file")
+		}
+		key = Cfg.DefaultConfig
 	}
 
 	entry, ok := Cfg.Configs[key]

--- a/rsbe/config_loader.go
+++ b/rsbe/config_loader.go
@@ -9,7 +9,7 @@ import (
 
 // TestConfig represents the structure of the test configuration file
 type TestConfig struct {
-	Environment string                  `yaml:"environment"`
+	Environment string                 `yaml:"environment"`
 	Configs     map[string]ConfigEntry `yaml:"configs"`
 }
 
@@ -64,7 +64,7 @@ func GetConfig(key string) (*Config, error) {
 
 	// Set AuthType if provided, otherwise default to basic
 	if entry.AuthType != "" {
-		config.AuthType = AuthType(entry.AuthType)
+		config.AuthType = entry.AuthType
 	} else {
 		config.AuthType = AuthTypeBasic
 	}

--- a/rsbe/main_test.go
+++ b/rsbe/main_test.go
@@ -71,8 +71,12 @@ func setupTestServerClient(ts *httptest.Server) {
 }
 
 func setupLocalhostClient() {
-	//c, err := GetConfig("basic")
-	c, err := GetConfig("cookie")
+
+	// passing UseDefaultConfig to GetConfig uses the default configuration
+	// specified in the config file under the "default_config" key.
+	// This allows tests to specify which auth method to use without
+	// changing the test code, by simply changing the config file.
+	c, err := GetConfig(UseDefaultConfig)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Overview

    replace AuthType type with string
    
    Remove separate AuthType type and use string constants instead.
      This removes the need for package consumers to cast the
      ConfigEntry AuthType field to the AuthType type.


    update test configuration behavior
    
    Add functionality to support running the full test suite using various
      configurations through the use of a configuration key/value pair.
      If the "default_config" key is present in the configuration YAML
      file, and if the UseDefaultConfig key is passed to GetConfig(), then
      GetConfig() returns whichever config was specified as the default.
      This was put in place to allow the full test suite to be run against
      any configuration without having to change the test code. This
      functionality is useful for development because a developer might
      not have both the Rails and Go RSBE implementations available when
      testing.
    
      Changes:
    
      * Add the DefaultConfig field to the TestConfig type
      * Add the UseDefaultConfig string constant
      * Update GetConfig() to support the UseDefaultConfig functionality
      * Add comments describing the updated GetConfig() behavior
      * Update the setupLocalhostClient() function in main_test.go to pass
        the UseDefaultConfig key to GetConfig()

    Update README
    Update example config files